### PR TITLE
updated slug for edit-link

### DIFF
--- a/maintenance.php
+++ b/maintenance.php
@@ -55,7 +55,7 @@ class YellowMaintenance {
             $page->set("description", $this->yellow->language->getTextHtml("maintenanceDescription"));
             $pageError = "";
             if ($this->yellow->extension->isExisting("edit")) {
-                $pageError .= str_replace([ "@url", "@ip" ], [ $page->get("pageEditUrl"), $this->yellow->toolbox->getServer("REMOTE_ADDR") ], $this->yellow->language->getText("maintenancePageError"));
+                $pageError .= str_replace([ "@url", "@ip" ], [ $page->get("editPageUrl"), $this->yellow->toolbox->getServer("REMOTE_ADDR") ], $this->yellow->language->getText("maintenancePageError"));
             }
             $page->error(503, $pageError);
         }


### PR DESCRIPTION
Maybe the slug has changed from `pageEditUrl` to `editPageUrl`. However, the old one didn't worked as intended.